### PR TITLE
Don't emit click event when node or canvas was dragged

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -432,7 +432,12 @@ export class PixiGraph<NodeAttributes extends BaseNodeAttributes = BaseNodeAttri
 
   private createNode(nodeKey: string, nodeAttributes: NodeAttributes) {
     const node = new PixiNode();
+    let mouseMoved = false
     node.on('mousemove', (event: MouseEvent) => {
+      if (this.mousedownNodeKey === nodeKey) {
+        mouseMoved = true
+      }
+    
       this.emit('nodeMousemove', event, nodeKey);
     });
     node.on('mouseover', (event: MouseEvent) => {
@@ -448,6 +453,7 @@ export class PixiGraph<NodeAttributes extends BaseNodeAttributes = BaseNodeAttri
       this.emit('nodeMouseout', event, nodeKey);
     });
     node.on('mousedown', (event: MouseEvent) => {
+      mouseMoved = false
       this.mousedownNodeKey = nodeKey;
 
       if (this.nodeDragging) {
@@ -460,7 +466,7 @@ export class PixiGraph<NodeAttributes extends BaseNodeAttributes = BaseNodeAttri
     node.on('mouseup', (event: MouseEvent) => {
       this.emit('nodeMouseup', event, nodeKey);
       // why native click event doesn't work?
-      if (this.mousedownNodeKey === nodeKey) {
+      if (this.mousedownNodeKey === nodeKey && !mouseMoved) {
         this.emit('nodeClick', event, nodeKey);
       }
     });


### PR DESCRIPTION
Fixes https://height.app/dWwdXWnlP/T-1437.

If you hold the mouse on the node, drag it then release it, graph treats it as a node click and emits an event.

This PR fixes it by detecting if the mouse has moved since a `mousedown` event was received by a node. If true, click event won't be emitted.